### PR TITLE
dep: update to use napi

### DIFF
--- a/example/develop.js
+++ b/example/develop.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 var framebuffer = require('../lib/framebuffer');

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var ioctl = require('ioctl');
+var ioctl = require('ioctl-napi');
 var mmap = require('mmap-io');
 var constants = require('./constants');
 var structs = require('./structs');

--- a/lib/structs.js
+++ b/lib/structs.js
@@ -1,6 +1,8 @@
-var ref = require('ref');
-var StructType = require('ref-struct');
-var ArrayType = require('ref-array');
+"use strict";
+
+var ref = require('ref-napi');
+var StructType = require('ref-struct-napi');
+var ArrayType = require('ref-array-napi');
 
 // definitions from linux/fb.h
 exports.Vinfo = StructType({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framebuffer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   },
   "homepage": "https://github.com/denghongcai/node-framebuffer",
   "dependencies": {
-    "ioctl": "^1.0.1",
-    "mmap-io": "^1.0.0",
-    "ref": "^1.0.2",
-    "ref-array": "^1.1.1",
-    "ref-struct": "^1.0.1"
+    "ioctl-napi": "^0.3.0",
+    "mmap-io": "^1.1.7",
+    "ref-array-napi": "^1.2.2",
+    "ref-napi": "^3.0.3",
+    "ref-struct-napi": "^1.1.1"
   }
 }


### PR DESCRIPTION
Module failed to compile with more recent versions of Node.js.  Replaced older dependencies with NAPI-compatible versions.